### PR TITLE
Add custom volunteers map

### DIFF
--- a/_data/config-nav.csv
+++ b/_data/config-nav.csv
@@ -2,7 +2,9 @@ display_name,stub,dropdown_parent
 Home,/
 Browse,/browse.html
 In Focus,,
-Map,/map.html
+Maps,,
+Collection Map,/map.html,Maps
+Texas Volunteers,/volunteers.html,Maps
 Locations,/locations.html
 Timeline,/timeline.html
 Data,/data.html

--- a/_data/config-volunteer-map.csv
+++ b/_data/config-volunteer-map.csv
@@ -1,0 +1,5 @@
+field,display_name,search
+county,County,true
+dates,Date,
+year,Year,true
+

--- a/_data/volunteer-rolls.csv
+++ b/_data/volunteer-rolls.csv
@@ -1,0 +1,63 @@
+title,dates,year,county,latitude,longitude
+Capt. William McK. Lambdin,undated,,Anderson County,31.809382,-95.62897918
+Capt. Semmes W. Parish,April 20,1901,Anderson County,31.809382,-95.62897918
+Capt. Augustus F. W. Macmanus,April 15,1901,Bexar County,29.4220479,-98.51677506
+Capt. John L. McAdoo,April 29,1901,Bexar County,29.4220479,-98.51677506
+Capt. W. S. Holman,March 23,1901,Bexar County,29.4220479,-98.51677506
+Capt. Thomas H. Franklin,March 1,1901,Caldwell County,29.88397419,-97.66532445
+Capt. Allen T. Smither,March 28,1901,Collin County,33.22442224,-96.61082958
+Capt. John R. Hunter,May 11,1901,Cooke County,33.66228033,-97.20157906
+Capt. Samuel Rosenfeld,May 13,1901,Dallas County,32.78543366,-96.80237232
+Capt. Ernest C. Lee,April 9,1901,Dallas County,32.78543366,-96.80237232
+Capt. Frederick S. Young,July 13,1901,Dallas County,32.78543366,-96.80237232
+Capt. Churchill Towles,March 16,1901,Dallas County,32.78543366,-96.80237232
+Capt. Alfred R. Burges,April 11,1901,Eastland County,32.30254502,-98.88467731
+Capt. Dupont B. Lyon,August 2,1901,"El Paso County",31.77771312,-106.4209499
+Capt. James F. Rhea,August 6,1901,Ellis County,32.36218096,-96.79027242
+Capt. Roger C. Roberdeau,April 23,1901,Fannin County,33.57765566,-96.1068114
+Capt. Jules E. Muchert,March 13,1901,Fannin County,33.57765566,-96.1068114
+Capt. Eugene J. Hernandez,April 26,1901,Fayette County,29.86169392,-96.88905248
+Capt. George T. West,April 10,1901,Fayette County,29.86169392,-96.88905248
+Capt. William Wallace Walker,April 17,1901,Fayette County,29.86169392,-96.88905248
+Capt. George McCormick,March 22,1901,Galveston County,29.42506688,-94.95140298
+Capt. Joe R. Gunn,May 13,1901,Galveston County,29.42506688,-94.95140298
+Capt. Edward W. Bryan,April 30,1901,Grayson County,33.64314547,-96.67613194
+Capt. William Walpole,July 6,1901,Grayson County,33.64314547,-96.67613194
+Capt. Frank B. Earnest,April 15,1901,Grayson County,33.64314547,-96.67613194
+Col. Louis M. Openheimer,April 1,1901,Gregg County,32.49491866,-94.82716344
+Capt. James W. Ireson,April 9,1901,Grimes County,30.52543068,-95.97156463
+Capt. Victor N. Theriot,May 29,1901,Harris County,29.77559071,-95.37431956
+Capt. George Willrich,March 29,1901,Harris County,29.77559071,-95.37431956
+Capt. Louis H. Younger,March 30,1901,Harris County,29.77559071,-95.37431956
+Capt. George M. Duncan,May 31,1901,Hill County,32.00690156,-97.12470529
+Capt. Edmund G. Shields,June 14,1901,Hill County,32.00690156,-97.12470529
+Capt. Richard B. Levy,March 18,1901,Hunt County,33.15538157,-96.11235423
+Capt. Charles A. Duff,April 16,1901,Hunt County,33.15538157,-96.11235423
+Capt. Joseph F. Nichols,April 9,1901,Jefferson County,29.9227377,-94.12160795
+Capt. John D. McRae,April 11,1901,Jefferson County,29.9227377,-94.12160795
+Capt. John D. McRae,undated,,Jefferson County,29.9227377,-94.12160795
+Capt. Charles S. Mitchell,Jr. May 27,1901,McLennan County,31.55008431,-97.15934414
+Capt. William McK. Lambdin,May 22,1901,McLennan County,31.55008431,-97.15934414
+Capt. James K. Gililland,May 9,1901,Montague County,33.65747627,-97.72887216
+Capt. Arthur R. Sholars,May 20,1901,Mt. Pleasant,33.15293063,-94.97268558
+Capt. Charles G. Bierbower,March 28,1901,Nacogdoches County,31.61250156,-94.64737528
+Capt. Auzi B. Kelly,March 15,1901,Navarro County,32.07758023,-96.45995932
+Capt. Roy W. Hearne,March 19,1901,Nueces County,27.7928793,-97.63636694
+Capt. Hiram C. Baker,April 10,1901,Orange County,30.13043316,-93.89626663
+Capt. Hampson Gary,August 14,1901,Robertson County,31.0507427,-96.4946931
+Capt. John L. Veazey,June 28,1901,San Patricio County,28.03536435,-97.4869094
+Capt. Richard L. Jarvis,May 29,1901,Smith County,32.36126519,-95.28727157
+Capt. Gordon Boone,May 13,1901,Tarrant County,32.76996144,-97.32035119
+Capt. V. J. Dumas,May 27,1901,Tarrant County,32.76996144,-97.32035119
+Capt. Armistead S. Fisher,June 14,1901,Tarrant County,32.76996144,-97.32035119
+Capt. Armistead S. Fisher,undated,,Tarrant County,32.76996144,-97.32035119
+Capt. Walter L. Smith,March 20,1901,Tom Green County,31.3955819,-100.4318719
+Capt. Shelton F. Leake,April 19,1901,Tom Green County,31.3955819,-100.4318719
+Capt. Ed L. Richards,April 1,1901,Travis County,30.34414392,-97.74376158
+Capt. Howard S. Leffler,April 4,1901,Travis County,30.34414392,-97.74376158
+Capt. Edwin A. Hammon,May 31,1901,Uvalde County,29.28638662,-99.7676281
+Capt. Joe S. Marks,May 10,1901,Victoria County,28.77205688,-96.99895602
+Capt. Earle E. Perrenot,April 1,1901,Victoria County,28.77205688,-96.99895602
+Capt. Oscar E. Cockrill,July 1,1901,Walker County,30.7281011,-95.56518378
+Capt. John F. Green,March 26,1901,Webb County,27.64488502,-99.39026976
+Capt. Nathan Lapowski,March 30,1901,Wise County,33.23614329,-97.71286357

--- a/_includes/js/volunteer-map-js.html
+++ b/_includes/js/volunteer-map-js.html
@@ -1,0 +1,141 @@
+{%- assign items = site.data.volunteer-rolls | where_exp: 'item','item.latitude' -%}
+{%- assign fields = site.data.config-volunteer-map -%}
+<link rel="stylesheet" href="{{ '/assets/lib/leaflet/leaflet.css' | relative_url }}">
+<link rel="stylesheet" href="{{ '/assets/lib/leaflet/leaflet.fusesearch.css' | relative_url }}">
+<link rel="stylesheet" href="{{ '/assets/lib/leaflet/MarkerCluster.css' | relative_url }}">
+<link rel="stylesheet" href="{{ '/assets/lib/leaflet/MarkerCluster.Default.css' | relative_url }}">
+<!-- load leaflet dependencies -->
+<script src="{{ '/assets/lib/leaflet/leaflet.js' | relative_url }}"></script>
+<script src="{{ '/assets/lib/leaflet/fuse.min.js' | relative_url }}"></script>
+<script src="{{ '/assets/lib/leaflet/leaflet.fusesearch.js' | relative_url }}"></script>
+<script src="{{ '/assets/lib/leaflet/leaflet.markercluster.js' | relative_url }}"></script>
+<script src="{{ '/assets/lib/leaflet/leaflet.markercluster.freezable.js' | relative_url }}"></script>
+
+<script>
+(function(){
+    /* add collection map data */
+    var geodata = { "type": "FeatureCollection", "features": [ 
+    {% for item in items %}
+    { "type":"Feature", "geometry":{ "type":"Point", "coordinates":[{{ item.longitude | strip }},{{ item.latitude | strip }}] }, "properties":
+    { "title": {{ item.title | jsonify }}, 
+    {% for f in fields %}{{ f.field | jsonify }}: {{ item[f.field] | jsonify }},{% endfor %}{% if item.youtubeid %} "youtube": {{ item.youtubeid | jsonify }}, {% endif %}
+    "format": {{ item.format | jsonify }}, {% if  item.filename contains '/' %}"filename": "{{ item.filename }}" {% else %}"filename":{{ '/objects/' | relative_url | append: item.filename | jsonify }}{% endif %}, "id": {{ item.objectid | jsonify }} } }{% unless forloop.last %}, {% endunless %}{% endfor %}
+    ]};
+
+    /* init map and set zoom */
+    if (window.location.hash) {
+        /* if url has a hash, it is split by comma into coordinates that set the view */
+        var hashfilter = decodeURIComponent(location.hash.substr(1));
+        var latitudeHash = hashfilter.split(',')[0]
+        var longitudeHash = hashfilter.split(',')[1]
+        var map = L.map('map').setView([latitudeHash,longitudeHash],16);
+    } else {
+        var map = L.map('map').setView([{{ page.latitude | default: 46.727485 }},{{ page.longitude | default: -117.014185 }}],{{ site.data.theme.zoom-level | default: 5 }});
+    }
+
+    /* add map layer options */
+    var Esri_WorldStreetMap = L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer/tile/{z}/{y}/{x}', {
+        attribution: 'Tiles &copy; Esri &mdash; Source: Esri, DeLorme, NAVTEQ, USGS, Intermap, iPC, NRCAN, Esri Japan, METI, Esri China (Hong Kong), Esri (Thailand), TomTom, 2012'
+    });
+    var Esri_NatGeoWorldMap = L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/NatGeo_World_Map/MapServer/tile/{z}/{y}/{x}', {
+        attribution: 'Tiles &copy; Esri &mdash; National Geographic, Esri, DeLorme, NAVTEQ, UNEP-WCMC, USGS, NASA, ESA, METI, NRCAN, GEBCO, NOAA, iPC',
+        maxZoom: 16
+    });
+    var Esri_WorldImagery = L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}', {
+        attribution: 'Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community'
+    });
+    /* add base map switcher */
+    var baseMaps = {
+        "Esri World StreetMap": Esri_WorldStreetMap,
+        "Esri National Geo": Esri_NatGeoWorldMap,
+        "Esri Imagery": Esri_WorldImagery
+    };
+    L.control.layers(baseMaps).addTo(map);
+    /* load base map */
+    {{ page.map-base | default: 'Esri_WorldStreetMap' }}.addTo(map);
+
+    
+    /* add leaflet-fusesearch */
+    var options = {
+        title: 'Search Map Items',
+        locationholder: 'Search map items...',
+        threshold: {{ page.map-search-fuzziness | default: 0.35 }} 
+    };
+    var searchCtrl = L.control.fuseSearch(options);
+    searchCtrl.addTo(map);
+    searchCtrl.indexFeatures(geodata.features, {{ fields | where: 'search','true' | map: 'field' | unshift: 'title' | jsonify }});
+
+    /* create cluster group */
+    var markers = L.markerClusterGroup({ maxClusterRadius: {{ page.cluster-radius | default: 15 }}, singleMarkerMode: true , removeOutsideVisibleBounds: false });
+
+    /* function to create object popups */
+    function objectPopups(feature, layer) {
+        /* bind feature for search */
+        feature.layer = layer;
+        /* calculate item link */
+        // no item link
+        //var itemHref = '{{ "/item.html?id=" | relative_url }}' + feature.properties.id;
+        /* find object thumb based on format */
+        // no thumb
+        /*
+        var thumbSrc;
+        if (feature.properties.youtube) {
+            thumbSrc = 'https://img.youtube.com/vi/' +  feature.properties.youtube + '/default.jpg';
+        } else if (feature.properties.format && feature.properties.format.includes("image")) {
+            thumbSrc = feature.properties.filename;
+        } else if (feature.properties.format && feature.properties.format.includes("audio")) {
+            thumbSrc = '{{ "/assets/img/audio.svg" | relative_url }}';
+        } else if (feature.properties.format && feature.properties.format.includes("video")) {
+            thumbSrc = '{{ "/assets/img/video.svg" | relative_url }}'; 
+        } else if (feature.properties.format && feature.properties.format.includes("pdf")) {
+            thumbSrc = '{{ "/assets/img/pdf.svg" | relative_url }}';    
+        } else {
+            thumbSrc = '{{ "/assets/img/file.svg" | relative_url }}';
+        }
+        */
+        /* create popup content */
+        /*
+        var popupTemplate = '<h4><a class="text-dark" href="' + itemHref + '">' +
+            feature.properties.title + '</a></h4><div class="text-center"><a href="' + itemHref + 
+            '" ><img class="mapthumb img-thumb" src="' +  thumbSrc + '" alt="item thumbnail"></a></div><p class="mt-1">';
+        */
+        var popupTemplate = '<h4>' + feature.properties.title + '</h4><p class="mt-1">';
+        /* add metadata fields */
+        {% for f in fields %}{% if f.display_name %}
+        if (feature.properties[{{ f.field | jsonify }}]) {
+            popupTemplate += '<strong>{{ f.display_name }}:</strong> ' + feature.properties[{{ f.field | jsonify }}] + '<br>'; 
+        }
+        {% endif %}{% endfor %}
+        popupTemplate += '</p>';
+        /* add object link button to popup */
+        //popupTemplate += '<div class="text-center"><a class="btn btn-light" href="' + itemHref + '" >View Item</a></div>';
+        /* add object popup to map layer */
+        layer.bindPopup(popupTemplate);
+    }
+    /* function to add objects to map */
+    function objectMarkers(feature,latlng) {
+        var marker = L.marker(latlng);
+        {% if site.data.theme.map-cluster == true %}markers.addLayer(marker);{% endif %}
+        return marker;
+    }
+
+    /* use geoJson features to add objects to map */
+    L.geoJson(geodata, {
+        onEachFeature: objectPopups,
+        pointToLayer: objectMarkers
+    }){% if site.data.theme.map-cluster != true %}.addTo(map);{% else %};
+    map.addLayer(markers);{% endif %}
+    
+    {% if site.data.theme.map-cluster == true and site.data.theme.map-search == true %}
+    /* uncluster when search is clicked */
+    document.querySelector('a.button').addEventListener("click", function() {
+        markers.disableClustering();
+    });
+    /* recluster when search is closed */
+    document.querySelector('a.close').addEventListener("click", function() {
+        markers.enableClustering();
+        document.querySelector('input.search-input').value = "";
+    });{% endif %}
+
+})();
+</script>

--- a/pages/volunteers.md
+++ b/pages/volunteers.md
@@ -1,0 +1,12 @@
+---
+title: Texas Volunteers
+layout: default
+permalink: /volunteers.html
+# center of the map
+latitude: 28.0
+longitude: -93.0
+# custom map set up
+custom-foot: js/volunteer-map-js.html
+---
+
+<div id="map"></div>


### PR DESCRIPTION
@laurenpv85 and @Rodpinar this PR adds a new custom map page connected to the volunteer-roll data. Since the volunteer's don't have an image or "item page", there is no thumb nail or link displayed--just the text information. 

I added a link in the nav as a dropdown with the "Maps" heading--> obviously you could reconfigure that to be any where in the nav that makes sense!